### PR TITLE
[Build/CI] Add multi-cores build on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ script:
 - mkdir build
 - cd build
 - if [ "${TRAVIS_OS_NAME}" = "linux" ]; then cmake .. -DWITH_QT5=On; fi
-- make
+- make -j2
 - make install
 after_success:
 - pwd && sh ../script_create_bin_dist.sh ${TRAVIS_OS_NAME} && ls


### PR DESCRIPTION
VMs on Travis have up to two cores... it could speed up a little the CI process.