### PR TITLE
Fix for linking problem

### DIFF
--- a/src/interface/test_ISA0/CMakeLists.txt
+++ b/src/interface/test_ISA0/CMakeLists.txt
@@ -8,5 +8,9 @@ add_executable(test_ISA0 TestIsabelle.cpp
 						 include_isa/Point.cpp
 						 include_isa/addon_ParamChantierPhotogram.cpp
 						 include_isa/Str_addon_ParamChantierPhotogram.cpp)
-target_link_libraries(test_ISA0 elise ${X11_LIBRARIES} ${WINSOCK2_LIBRAIRIE})
+target_link_libraries(test_ISA0 ${OPENGL_LIBRARIES}
+                                ${QT_LIBRARIES}
+                                elise
+                                ${X11_LIBRARIES}
+                                ${WINSOCK2_LIBRAIRIE})
 INSTALL(TARGETS test_ISA0 RUNTIME DESTINATION ${Install_Dir})


### PR DESCRIPTION
The code in src/interface/test_ISA0 does not build without linking to Qt. I put a fix. This imitates the existing CMakeLists.txt in src/interface. 