### PR TITLE
Fix MinGW compile error:

### DIFF
--- a/include/StdAfx.h
+++ b/include/StdAfx.h
@@ -312,4 +312,8 @@ Im2DGen AllocImGen(Pt2di aSz,const std::string & aName);
 
 #include "general/PlyFile.h"
 
+#ifndef uint
+	typedef unsigned uint;
+#endif
+
 #endif //_ELISE_STDAFX_H

--- a/src/uti_image/NewRechPH/ExternNewRechPH.h
+++ b/src/uti_image/NewRechPH/ExternNewRechPH.h
@@ -41,6 +41,8 @@ Header-MicMac-eLiSe-25/06/2007*/
 #ifndef _ExternNewRechPH_H_
 #define _ExternNewRechPH_H_
 
+#include "../../../include/StdAfx.h"
+
 template<class T1,class T2> Im2D_U_INT1 MakeFlagMontant(Im2D<T1,T2> anIm)
 {
     Pt2di aSz = anIm.sz();


### PR DESCRIPTION
1.Add type define for uint in the rear of StdAfx cause uint is not a standard C/C++type
2.Import header in ExternNewRechPH.h for missing element type define like: Pt2di, Im2D_U_INT1, TIm2D, etc.