### PR TITLE
Add "data" directory to binary archive

### DIFF
--- a/script_create_bin_dist.sh
+++ b/script_create_bin_dist.sh
@@ -3,6 +3,7 @@ echo 'creation de l archive binaire : '$nomArchive
 mkdir $nomArchive
 cp -R ../bin $nomArchive
 cp -R ../binaire-aux $nomArchive
+cp -R ../data $nomArchive
 mkdir $nomArchive/include
 cp -R ../include/XML_MicMac $nomArchive/include
 cp -R ../include/XML_GEN $nomArchive/include


### PR DESCRIPTION
Fix the issue #20 "Data directory missing in precompiled release package for linux"