### PR TITLE
More options for PIMs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -610,6 +610,10 @@ ENDIF()
 
 # DEFINITION : des preprocesseurs windows
 IF (MSVC)
+	if (CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)
+		set (CMAKE_INSTALL_PREFIX "${PROJECT_SOURCE_DIR}" CACHE PATH "default install path" FORCE )
+	endif()
+
 	set (CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} /LARGEADDRESSAWARE" )
 	# Zm131 -> Erreur de compilation sous windows 7 avec Cuda et Boost
 	if (${CUDA_ENABLED})

--- a/src/TpMMPD/DIDRO/divers.cpp
+++ b/src/TpMMPD/DIDRO/divers.cpp
@@ -1269,6 +1269,8 @@ int statRadianceVarioCam_main(int argc,char ** argv)
         }
         // fin iter sur les mesures appuis flottant
     }
+	
+	return EXIT_SUCCESS;
 }
 
 

--- a/src/uti_phgrm/CPP_C3DC.cpp
+++ b/src/uti_phgrm/CPP_C3DC.cpp
@@ -800,7 +800,10 @@ void cAppli_MPI2Mnt::DoMTD()
                           + PATTERN_QUOTE(mCFPI->mStrPat)
                           + std::string(" ") + mCFPI->mMMI->GetOriOfEtat()
                           + mStrRep
-                          + " DoMEC=0  Purge=true ZoomI=4 ZoomF=2  IncMax=1.0 " +
+                          + " DoMEC=0 Purge=true "
+                          + " ZoomI=" + ToString(mDeZoom * 2)
+                          + " ZoomF=" + ToString(mDeZoom)
+                          + " IncMax=1.0 "
                           + " DirMEC=" + mDirMTD
                           + " UseTA=" + ToString(mUseTA)
                           + " ZoomF=" + ToString(mDeZoom)
@@ -858,6 +861,11 @@ cAppli_MPI2Mnt::cAppli_MPI2Mnt(int argc,char ** argv) :
                     << EAM(mUseTA,"UseTA",true,"Use TA as filter when exist (Def=false)",eSAM_InternalUse)
                     << EAM(mResolIm,"RI",true,"Resol Im, def=1 ",eSAM_InternalUse)
                     << EAM(mSeuilE,"SeuilE",true,"Seuil d'etirement des triangle, Def=5")
+                    << EAM(mDeZoom, "ZoomF", true, "ZoomF, Def=2")
+                    << EAM(mDirMTD, "DirMTD", true, "Subdirectory where the temporary results will be stored, Def=PIMs-TmpMnt/")
+                    << EAM(mDirOrtho, "DirOrtho", true, "Subdirectory for ortho images, Def=PIMs-ORTHO/")
+                    << EAM(mDirBasc, "DirBasc", true, "Subdirectory for surface model, Def=PIMs-TmpBasc/")
+                    << EAM(mNameMerge, "NameMerge", true, "BaseName of the surface model (*.xml), Def=PIMs-Merged.xml")
    );
 
    mResolIm  /= mDeZoom;


### PR DESCRIPTION
Hi all,

To allow for different resolutions of the PIMs surface model such as ZoomF=1,2,4 or 8 (similar to Malt), I added the option to set ZoomF for Pims2MNT
	- in cAppli_MPI2Mnt::cAppli_MPI2Mnt
	- and void cAppli_MPI2Mnt::DoMTD()
This allows to set ZoomF independently for the surface reconstruction (PIMs) and the interpolation (Pims2MNT).

The old default behavior would now be:
	- Pims Forest .*.JPG Referenced ZoomF=4
	-	Pims2MNT Forest DoOrtho=0 ZoomF=2
or as the default:
	- Pims Forest .*.JPG Referenced
	- Pims2MNT Forest DoOrtho=0

With the update it is now possible to set:
Pims Forest .*.JPG Referenced ZoomF=1
Pims2MNT Forest DoOrtho=0 ZoomF=1

I also added options to change the default names of DirMTD, DirOrtho, DirBasc, NameMerge
	- in cAppli_MPI2Mnt::cAppli_MPI2Mnt
such as:
Pims2MNT Forest DoOrtho=0 ZoomF=1 DirMTD=PIMs-Tmp/ DirOrtho=PIMs-Ortho/ DirBasc=PIMs-DSM/ NameMerge=DSM.xml

This is my first pull request. I hope it is ok as is and can be merged.

Best,
Thorsten