### PR TITLE
Apero2Meshlab: Fix a bug with recent versions of imagemagick

### DIFF
--- a/include/private/externalToolHandler.h
+++ b/include/private/externalToolHandler.h
@@ -41,7 +41,7 @@ class ExternalToolHandler
 public:
 	ExternalToolHandler();
 
-	// returns a ExternalToolItem for i_tool commande
+	// returns an ExternalToolItem for i_tool command
 	const ExternalToolItem & get( const std::string &i_tool );
 private:
 	list<std::string> m_pathDirectories; // the list of directories in PATH environment variable


### PR DESCRIPTION
Latest version of imagemagick disable ephemeral due to potential security issue
- Fix this in Apero2Meshlab by using convert and rm
- Enhance portability of Apero2Meshlab by using g_externalToolHandler and ELISE_STR_DIR
- Fix some minor typos