### PR TITLE
Re-enable travis build for osx

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,13 +5,17 @@ matrix:
     dist: trusty
     sudo: required
     compiler: gcc
+  - os: osx
+    osx_image: xcode9.3
 before_install:
 - if [ "${TRAVIS_OS_NAME}" = "linux" ]; then sudo apt-get update -qq && sudo apt-get
   install -qq qtbase5-dev; fi
+- if [ "${TRAVIS_OS_NAME}" = "osx" ]; then brew update && brew install qt && export PATH="/usr/local/opt/qt/bin:$PATH"; fi
+#Hombrew bug: https://github.com/Homebrew/homebrew-core/issues/8392
 script:
 - mkdir build
 - cd build
-- if [ "${TRAVIS_OS_NAME}" = "linux" ]; then cmake .. -DWITH_QT5=On; fi
+- cmake .. -DWITH_QT5=On
 - make -j2
 - make install
 after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,8 @@ matrix:
     compiler: gcc
   - os: osx
     osx_image: xcode9.3
+    compiler: clang
+
 before_install:
 - if [ "${TRAVIS_OS_NAME}" = "linux" ]; then sudo apt-get update -qq && sudo apt-get
   install -qq qtbase5-dev; fi

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required( VERSION 2.8.1 )
+cmake_minimum_required(VERSION 2.8.12)
 project(MICMAC)
 
 function(print_list list_name)

--- a/CodeExterne/Poisson/CMakeLists.txt
+++ b/CodeExterne/Poisson/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required( VERSION 2.8.1 )
+cmake_minimum_required(VERSION 2.8.12)
 
 include_directories(${CMAKE_CURRENT_SOURCE_DIR}/include)
 set(POISSON_SRC_DIR ${CMAKE_CURRENT_SOURCE_DIR}/src)

--- a/CodeExterne/rnx2rtkp/CMakeLists.txt
+++ b/CodeExterne/rnx2rtkp/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.1)
+cmake_minimum_required(VERSION 2.8.12)
 
 include_directories (${CMAKE_CURRENT_SOURCE_DIR}/include)
 set(RNX2RTKP_SRC_DIR ${CMAKE_CURRENT_SOURCE_DIR}/src)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -175,7 +175,7 @@ else()
 endif()
 
 if( ${qt_version} EQUAL 5 )
-	qt5_use_modules(${libElise} Widgets Core Gui Xml Concurrent OpenGL)
+	target_link_libraries(${libElise} Qt5::Widgets Qt5::Core Qt5::Gui Qt5::Xml Qt5::Concurrent Qt5::OpenGL)
 endif()
 
 INSTALL(TARGETS ${libElise} ARCHIVE DESTINATION ${BUILD_PATH_LIB})

--- a/src/interface/CMakeLists.txt
+++ b/src/interface/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8)
+cmake_minimum_required(VERSION 2.8.12)
 
 ADD_SUBDIRECTORY(test_ISA0)
 

--- a/src/saisieQT/CMakeLists.txt
+++ b/src/saisieQT/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.1)
+cmake_minimum_required(VERSION 2.8.12)
 project(saisieQT)
 
 if(POLICY CMP0020)


### PR DESCRIPTION
- This re-enable travis build for osx. It should be ok for continuous build tests but not for automated package construction. I will rework on the dmg construction scripts present in the `config` directory or maybe simply work on a Homebrew formula in a separate commit.  
- I pulled out `qt5_use_modules` from the CMakeList since it's deprecated and it will trigger configuration failure with recent version of QT5 . The use of `target_build_libraries` with QT require at least cmake 2.8.12 