### PR TITLE
Update GlExtension.cpp with proper ifdef for macOS

### DIFF
--- a/src/saisieQT/GlExtensions.cpp
+++ b/src/saisieQT/GlExtensions.cpp
@@ -4,7 +4,11 @@
 	#include <windows.h> 
 #endif
 
-#include "GL/gl.h"
+#ifdef ELISE_Darwin
+	#include "OpenGL/gl.h"
+#else
+	#include "GL/gl.h"
+#endif
 
 #include <list>
 #include <algorithm>


### PR DESCRIPTION
should fix issue reported here https://github.com/micmacIGN/micmac/issues/41#issuecomment-468742666
- I can't explain why the error reported is not triggered on travis...
- the fix is ok, but we should migrate the file to use the precompiled header since the proper ifdef exists in this file