### PR TITLE
  [Build] update travis for macOS mojave and fixes #113

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,9 @@ matrix:
   - os: osx
     osx_image: xcode9.3
     compiler: clang
+  - os: osx
+    osx_image: xcode10.2
+    compiler: clang
 
 before_install:
 - if [ "${TRAVIS_OS_NAME}" = "linux" ]; then sudo apt-get update -qq && sudo apt-get

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -257,7 +257,7 @@ if(${WITH_CPP11})
 	if(NOT MSVC)
 		message(STATUS "-----> Compile with c++11 support")
 		# support c++11
-		if(NOT DARWIN) #TODO: if(NOT clang), the "precomopiled header bug" it tries to fix, is clang related, not osx related   
+		if(NOT DARWIN) #TODO: if(NOT clang) => the "precompiled header bug" it tries to fix is clang related, not osx related   
 		set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
 		ELSE()
 		# MODIF MPD, reverse Gregoire, car gnu++11 mulitplie par 6 le temps de compilation

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -175,7 +175,11 @@ endif()
 install(TARGETS ${libElise} ARCHIVE DESTINATION ${BUILD_PATH_LIB})
 
 if(${WITH_HEADER_PRECOMP} AND (CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_IS_CLANG))
-	enable_precompiled_headers_GCC(StdAfx.h ${libElise} "-fPIC -std=gnu++11")
+	if(CMAKE_OSX_SYSROOT) # for macOS > 10.14, it contains the path to the SDK/headers. checking this fixes issue #113
+		enable_precompiled_headers_GCC(StdAfx.h ${libElise} "-fPIC -std=gnu++11 -isysroot ${CMAKE_OSX_SYSROOT}")
+	else()
+		enable_precompiled_headers_GCC(StdAfx.h ${libElise} "-fPIC -std=gnu++11")
+	endif()
 	set(precompiled_header ${precompiled_header} PARENT_SCOPE)
 endif()
 


### PR DESCRIPTION
this Pull request
- Add macOS mojave on travis
- close #113
While the fix is not 100% elegant, it really target the culprit.
It's way better and durable than pointing user to the `open *.sdk ` work around (that wont work with 10.15)