### PR TITLE
[Build] GIMMI is portable (fix #118)

### DIFF
--- a/src/GIMMI/Aperi.cpp
+++ b/src/GIMMI/Aperi.cpp
@@ -106,7 +106,7 @@ void Aperi::mm3d(){
             this->close();
             p.setWorkingDirectory(path_s.c_str());
             p.waitForFinished(-1);
-            qDebug() <<  get_current_dir_name();
+            qDebug() <<  QDir::currentPath();
             qDebug() <<  cmd.c_str() ;
             p.start(cmd.c_str());
             p.setReadChannel(QProcess::StandardOutput);

--- a/src/GIMMI/Bascule.cpp
+++ b/src/GIMMI/Bascule.cpp
@@ -156,7 +156,7 @@ void Bascule::mm3d(){
             this->close();
             p.setWorkingDirectory(path_s.c_str());
             p.waitForFinished(-1);
-            qDebug() <<  get_current_dir_name();
+            qDebug() <<  QDir::currentPath();
             qDebug() <<  cmd.c_str() ;
             p.start(cmd.c_str());
             p.setReadChannel(QProcess::StandardOutput);

--- a/src/GIMMI/C3dc.cpp
+++ b/src/GIMMI/C3dc.cpp
@@ -421,7 +421,7 @@ void C3dc::mm3d(){
             //       cons.show();
             p.setWorkingDirectory(path_s.c_str());
             p.waitForFinished(-1);
-            qDebug() <<  get_current_dir_name();
+            qDebug() <<  QDir::currentPath();
             qDebug() <<  cmd.c_str() ;
             p.start(cmd.c_str());
             p.setReadChannel(QProcess::StandardOutput);

--- a/src/GIMMI/Campari.cpp
+++ b/src/GIMMI/Campari.cpp
@@ -368,7 +368,7 @@ rPCStd.erase(0,4);
             this->close();
             p.setWorkingDirectory(path_s.c_str());
             p.waitForFinished(-1);
-            qDebug() <<  get_current_dir_name();
+            qDebug() <<  QDir::currentPath();
             qDebug() <<  cmd.c_str() ;
             p.start(cmd.c_str());
             p.setReadChannel(QProcess::StandardOutput);

--- a/src/GIMMI/Cmd.cpp
+++ b/src/GIMMI/Cmd.cpp
@@ -76,7 +76,7 @@ void Cmd::mm3d(){
 
             p.setWorkingDirectory(path_s.c_str());
             p.waitForFinished(-1);
-            qDebug() <<  get_current_dir_name();
+            qDebug() <<  QDir::currentPath();
             qDebug() <<  cmd.c_str() ;
             p.start(cmd.c_str());
             p.setReadChannel(QProcess::StandardOutput);

--- a/src/GIMMI/Convert2GenBundle.cpp
+++ b/src/GIMMI/Convert2GenBundle.cpp
@@ -264,7 +264,7 @@ void Convert2GenBundle::mm3d(){
         //       cons.show();
         p.setWorkingDirectory(path_s.c_str());
         p.waitForFinished(-1);
-        qDebug() <<  get_current_dir_name();
+        qDebug() <<  QDir::currentPath();
         qDebug() <<  cmd.c_str() ;
         p.start(cmd.c_str());
         p.setReadChannel(QProcess::StandardOutput);

--- a/src/GIMMI/CropRPC.cpp
+++ b/src/GIMMI/CropRPC.cpp
@@ -169,7 +169,7 @@ void CropRPC::mm3d(){
         this->close();
         p.setWorkingDirectory(path_s.c_str());
         p.waitForFinished(-1);
-        qDebug() <<  get_current_dir_name();
+        qDebug() <<  QDir::currentPath();
         qDebug() <<  cmd.c_str() ;
         p.start(cmd.c_str());
         p.setReadChannel(QProcess::StandardOutput);

--- a/src/GIMMI/MM2DPosSism.cpp
+++ b/src/GIMMI/MM2DPosSism.cpp
@@ -134,7 +134,7 @@ void MM2DPosSism::mm3d(){
             this->close();
             p.setWorkingDirectory(path_s.c_str());
             p.waitForFinished(-1);
-            qDebug() <<  get_current_dir_name();
+            qDebug() <<  QDir::currentPath();
             qDebug() <<  cmd.c_str() ;
             p.start(cmd.c_str());
             p.setReadChannel(QProcess::StandardOutput);

--- a/src/GIMMI/MainWindow.cpp
+++ b/src/GIMMI/MainWindow.cpp
@@ -2605,7 +2605,7 @@ void MainWindow::doSomething2(QListWidgetItem *item)
     qDebug() <<  pathProject ;
     p.setWorkingDirectory(pathProject);
     p.waitForFinished(-1);
-    qDebug() <<  get_current_dir_name();
+    qDebug() <<  QDir::currentPath();
     qDebug()<< item->text();
     
     QString cmd = "mm3d Vino "+ pathProject +"/"+ item->text();

--- a/src/GIMMI/Malt.cpp
+++ b/src/GIMMI/Malt.cpp
@@ -477,7 +477,7 @@ void Malt::mm3d(){
             //       cons.show();
             p.setWorkingDirectory(path_s.c_str());
             p.waitForFinished(-1);
-            qDebug() <<  get_current_dir_name();
+            qDebug() <<  QDir::currentPath();
             qDebug() <<  cmd.c_str() ;
             p.start(cmd.c_str());
             p.setReadChannel(QProcess::StandardOutput);

--- a/src/GIMMI/Meshlab.cpp
+++ b/src/GIMMI/Meshlab.cpp
@@ -102,7 +102,7 @@ pyFile = rPC->toPlainText().toStdString();
 
         p.setWorkingDirectory(path_s.c_str());
         p.waitForFinished(-1);
-        qDebug() <<  get_current_dir_name();
+        qDebug() <<  QDir::currentPath();
         qDebug() <<  cmd.c_str() ;
         p.start(cmd.c_str());
         p.setReadChannel(QProcess::StandardOutput);

--- a/src/GIMMI/SaisieMasq.cpp
+++ b/src/GIMMI/SaisieMasq.cpp
@@ -83,7 +83,7 @@ void SaisieMasq::mm3d(){
     if(msgBox2.exec() == QMessageBox::Yes){
         p.setWorkingDirectory(path_s.c_str());
         p.waitForFinished(-1);
-        qDebug() <<  get_current_dir_name();
+        qDebug() <<  QDir::currentPath();
         qDebug() <<  cmd.c_str() ;
         p.start(cmd.c_str());
         p.setReadChannel(QProcess::StandardOutput);

--- a/src/GIMMI/SaisiePts.cpp
+++ b/src/GIMMI/SaisiePts.cpp
@@ -224,7 +224,7 @@ QMessageBox msgBox2;
             //       cons.show();
             p.setWorkingDirectory(path_s.c_str());
             p.waitForFinished(-1);
-            qDebug() <<  get_current_dir_name();
+            qDebug() <<  QDir::currentPath();
             qDebug() <<  cmd.c_str() ;
             p.start(cmd.c_str());
             p.setReadChannel(QProcess::StandardOutput);

--- a/src/GIMMI/Tapas.cpp
+++ b/src/GIMMI/Tapas.cpp
@@ -900,7 +900,7 @@ void Tapas::mm3d(){
             this->close();
             p.setWorkingDirectory(path_s.c_str());
             p.waitForFinished(-1);
-            qDebug() <<  get_current_dir_name();
+            qDebug() <<  QDir::currentPath();
             qDebug() <<  cmd.c_str() ;
             p.start(cmd.c_str());
             p.setReadChannel(QProcess::StandardOutput);

--- a/src/GIMMI/Tapioca.cpp
+++ b/src/GIMMI/Tapioca.cpp
@@ -402,7 +402,7 @@ cmd = " mm3d Tapioca " + mode +" \""+ images +"\" "+ resom_str +" "+ resoM_str +
         //       cons.show();
         p.setWorkingDirectory(path_s.c_str());
         p.waitForFinished(-1);
-        qDebug() <<  get_current_dir_name();
+        qDebug() <<  QDir::currentPath();
         qDebug() <<  cmd.c_str() ;
         p.start(cmd.c_str());
         p.setReadChannel(QProcess::StandardOutput);

--- a/src/GIMMI/Tarama.cpp
+++ b/src/GIMMI/Tarama.cpp
@@ -215,7 +215,7 @@ QMessageBox msgBox2;
                 //       cons.show();
             p.setWorkingDirectory(path_s.c_str());
             p.waitForFinished(-1);
-            qDebug() <<  get_current_dir_name();
+            qDebug() <<  QDir::currentPath();
             qDebug() <<  cmd.c_str() ;
             p.start(cmd.c_str());
             p.setReadChannel(QProcess::StandardOutput);


### PR DESCRIPTION
This PR aim at fixing the compilation of GIMMI on non Linux OSes by replacing the use of Linux API by QT equivalents. It works fine on macOS (see #118) and it should be ok on Linux. It's not tested on Windows.