### PR TITLE
[Build] Remove void files (fix #126)

### DIFF
--- a/src/TpMMPD/SimuBBA/simurolshut.h
+++ b/src/TpMMPD/SimuBBA/simurolshut.h
@@ -1,5 +1,0 @@
-#ifndef SIMUROLSHUT_H
-#define SIMUROLSHUT_H
-
-#endif // SIMUROLSHUT_H
-

--- a/src/uti_files/cpp_xifgps2xml.h
+++ b/src/uti_files/cpp_xifgps2xml.h
@@ -1,5 +1,0 @@
-#ifndef CPP_XIFGPS2XML_H
-#define CPP_XIFGPS2XML_H
-
-#endif // CPP_XIFGPS2XML_H
-


### PR DESCRIPTION
Remove two void files which have Camel case counter part into the source tree. These file cause compilation failure on case insensitive filesystems.