### PR TITLE
normals exported in float64 if option 64B=true is used

### DIFF
--- a/src/geom3d/cElNuage3DMaille.cpp
+++ b/src/geom3d/cElNuage3DMaille.cpp
@@ -761,9 +761,9 @@ void cElNuage3DMaille::PlyPutFile
 
    if (aAddNormale)
    {
-       fprintf(aFP,"property float nx\n");
-       fprintf(aFP,"property float ny\n");
-       fprintf(aFP,"property float nz\n");
+       fprintf(aFP,"property %s nx\n",aTypeXYZ.c_str());
+       fprintf(aFP,"property %s ny\n",aTypeXYZ.c_str());
+       fprintf(aFP,"property %s nz\n",aTypeXYZ.c_str());
    }
 
    const char * aVCoul[3]={"red","green","blue"};
@@ -914,19 +914,39 @@ void cElNuage3DMaille::PlyPutDataVertex(FILE * aFP, bool aModeBin, int aAddNorma
        {
            Pt3dr aN = NormaleOfIndex(anI, aAddNormale);
 
-           float Nxyz[3];
-           Nxyz[0] = (float)aN.x;
-           Nxyz[1] = (float)aN.y;
-           Nxyz[2] = (float)aN.z;
-
-           if (aModeBin)
+           if (DoublePrec)
            {
-               int aNb= (int)fwrite(Nxyz, sizeof(float), 3, aFP);
-               ELISE_ASSERT(aNb==3,"cElNuage3DMaille::PlyPutDataVertex-Normale");
+               double Nxyz[3];
+               Nxyz[0] = (double)aN.x;
+               Nxyz[1] = (double)aN.y;
+               Nxyz[2] = (double)aN.z;
+
+               if (aModeBin)
+               {
+                   int aNb= (int)fwrite(Nxyz, sizeof(double), 3, aFP);
+                   ELISE_ASSERT(aNb==3,"cElNuage3DMaille::PlyPutDataVertex-Normale");
+               }
+               else
+               {
+                   fprintf(aFP," %.6f %.6f %.6f", Nxyz[0], Nxyz[1], Nxyz[2]);
+               }
            }
            else
            {
-               fprintf(aFP," %.6f %.6f %.6f", Nxyz[0], Nxyz[1], Nxyz[2]);
+               float Nxyz[3];
+               Nxyz[0] = (float)aN.x;
+               Nxyz[1] = (float)aN.y;
+               Nxyz[2] = (float)aN.z;
+
+               if (aModeBin)
+               {
+                   int aNb= (int)fwrite(Nxyz, sizeof(float), 3, aFP);
+                   ELISE_ASSERT(aNb==3,"cElNuage3DMaille::PlyPutDataVertex-Normale");
+               }
+               else
+               {
+                   fprintf(aFP," %.6f %.6f %.6f", Nxyz[0], Nxyz[1], Nxyz[2]);
+               }
            }
        }
 


### PR DESCRIPTION
Change the type from float to float64 of the exported nx ny nz in Nuage2Ply if the option 64B=true is used.
When in lambert93 + NormByC=2 (nx ny nz are the image POV coordinates), we had an issue.