### PR TITLE
cLoadedImage: fix InterpoleOfEtape call in cEtapeMecComp.cpp with gcc-10

### DIFF
--- a/src/uti_phgrm/MICMAC/cLoadedImage.cpp
+++ b/src/uti_phgrm/MICMAC/cLoadedImage.cpp
@@ -194,7 +194,7 @@ template <class TypeEl> Im2D_REAL4 * cTplLoadedImage<TypeEl>::FirstFloatIm()
 
 
 
-
+template cInterpolateurIm2D<float> *InterpoleOfEtape(const cEtapeMEC & anEt,float *t1,double *t2);
 
 template <class TypeEl,class tBase> cInterpolateurIm2D<TypeEl>  * InterpoleOfEtape(const cEtapeMEC & anEt,TypeEl *,tBase *)
 // template <class TypeEl,class tBase> cInterpolateurIm2D<TypeEl>  InterpoleOfEtape(const cEtapeMEC & anEt)


### PR DESCRIPTION
With gcc-10 build fails with
```
cEtapeMecComp.cpp:(.text+0xdcd): undefined reference to `cInterpolateurIm2D* InterpoleOfEtape<float, double>(cEtapeMEC const&, float*, double*)'
```
The version of InterpoleOfEtape with typeEL=float, and tBase = double is not available out of the cpp file.
Adding explicitly this signature force the compiler to generate required method.

Fix issue #166 