### PR TITLE
add thread control through an env variable

### DIFF
--- a/src/interface/interface.cpp
+++ b/src/interface/interface.cpp
@@ -486,6 +486,11 @@ bool Interface::checkMicmac() {
               size_t size=sizeof(cpu_count) ;
               if (sysctlbyname("hw.ncpu",&cpu_count,&size,NULL,0)) cpu_count = 2;
         #endif
+	//// ADDED
+	//set number of process according to env variable MICMAC_MAX_THREADS if defined.
+    if(const char* env_p = std::getenv("MICMAC_MAX_THREADS"))
+        cpu_count = env_p;
+    //// END ADDED		
 	maxcpu = (settings->value("cpu").toString().isEmpty())? cpu_count : settings->value("cpu").toInt();
 	settings->setValue("cpu", maxcpu);
 

--- a/src/photogram/ChantierNameAssoc.cpp
+++ b/src/photogram/ChantierNameAssoc.cpp
@@ -577,7 +577,14 @@ int CalcNbProcSys()
     return sysinfo.dwNumberOfProcessors;
 #else
     // return GetValStrSys<int>("cat /proc/cpuinfo | grep processor  | wc -l");
-    return sysconf (_SC_NPROCESSORS_CONF);
+    //// MODIFIED
+    //set number of process according to env variable MICMAC_MAX_THREADS if defined.
+    if (const char* env_p = std::getenv("MICMAC_MAX_THREADS")) {
+        return atoi(env_p);
+    } else {
+        return sysconf (_SC_NPROCESSORS_CONF);
+    }
+    //// END MODIFED
 #endif
 }
 

--- a/src/uti_phgrm/MICMAC/cAppliMICMAC.cpp
+++ b/src/uti_phgrm/MICMAC/cAppliMICMAC.cpp
@@ -2218,9 +2218,22 @@ void cAppliMICMAC::ExeProcessParallelisable
            }
        } 
        fic.close();
-       mCout << " ---Launch processes through the Makefile\n";
 
-	bool makeSucceeded = launchMake( nomMakefile, "", ByProcess().Val() );
+       //// MODIFiED
+       //set number of process according to env variable MICMAC_MAX_THREADS if defined.
+       int thread_count;
+       const char* env_var = std::getenv("MICMAC_MAX_THREADS");
+       if (env_var != NULL)
+       {
+            thread_count = atoi(env_var);
+       }
+       else
+       {
+            thread_count = ByProcess().Val();
+       }
+       mCout << " ---Launch " << thread_count << " processes through the Makefile\n";
+       bool makeSucceeded = launchMake( nomMakefile, "", thread_count );
+       //// END MODIFIED
 
        if (StopOnEchecFils().Val())
         {    
@@ -2437,7 +2450,7 @@ void cAppliMICMAC::AnalyseOri(CamStenope * aCam ) const
 
 /*Footer-MicMac-eLiSe-25/06/2007
 
-Ce logiciel est un programme informatique servant �  la mise en
+Ce logiciel est un programme informatique servant �  la mise en
 correspondances d'images pour la reconstruction du relief.
 
 Ce logiciel est régi par la licence CeCILL-B soumise au droit français et
@@ -2453,17 +2466,17 @@ seule une responsabilité restreinte pèse sur l'auteur du programme,  le
 titulaire des droits patrimoniaux et les concédants successifs.
 
 A cet égard  l'attention de l'utilisateur est attirée sur les risques
-associés au chargement,  �  l'utilisation,  �  la modification et/ou au
-développement et �  la reproduction du logiciel par l'utilisateur étant 
-donné sa spécificité de logiciel libre, qui peut le rendre complexe �  
-manipuler et qui le réserve donc �  des développeurs et des professionnels
+associés au chargement,  �  l'utilisation,  �  la modification et/ou au
+développement et �  la reproduction du logiciel par l'utilisateur étant 
+donné sa spécificité de logiciel libre, qui peut le rendre complexe �  
+manipuler et qui le réserve donc �  des développeurs et des professionnels
 avertis possédant  des  connaissances  informatiques approfondies.  Les
-utilisateurs sont donc invités �  charger  et  tester  l'adéquation  du
-logiciel �  leurs besoins dans des conditions permettant d'assurer la
+utilisateurs sont donc invités �  charger  et  tester  l'adéquation  du
+logiciel �  leurs besoins dans des conditions permettant d'assurer la
 sécurité de leurs systèmes et ou de leurs données et, plus généralement, 
-�  l'utiliser et l'exploiter dans les mêmes conditions de sécurité. 
+�  l'utiliser et l'exploiter dans les mêmes conditions de sécurité. 
 
-Le fait que vous puissiez accéder �  cet en-tête signifie que vous avez 
+Le fait que vous puissiez accéder �  cet en-tête signifie que vous avez 
 pris connaissance de la licence CeCILL-B, et que vous en avez accepté les
 termes.
 Footer-MicMac-eLiSe-25/06/2007*/


### PR DESCRIPTION
----- context

This pull request respond to my needs of using micmac on a calculus cluster.
I couldn't let micmac to use all available computing cores on the cluster. 
I did so need to control the maximum number of threads created by micmac.

----- the commit message

The number of maximum usable threads can be controlled by the environment
variable MICMAC_MAX_THREADS. If not setted, all available threads will be
used (previous default). If setted with an integer, the given number will
be considered as the max number of usable threads.

CAUTION : there is no safeguard for the following edge cases :
* given integer is higher than available thread;
* given value is not an integer.