### PR TITLE
Pb gestion option envZ

### DIFF
--- a/src/uti_phgrm/CPP_Malt.cpp
+++ b/src/uti_phgrm/CPP_Malt.cpp
@@ -1364,7 +1364,11 @@ cAppliMalt::cAppliMalt(int argc,char ** argv) :
                mCom  =    mCom + " +UseEnvMNTInit=true"
                                +  std::string(" +EnvZInf=") + aEnvZInf
                                +  std::string(" +EnvZSup=") + aEnvZSup;
-           }
+           }else{
+	     mCom = mCom +" +UseEnvMNTInit=false"
+	       +  std::string(" +EnvZInf=")
+	       +  std::string(" +EnvZSup=");
+	   }
       }
 
       if (EAMIsInit(&aBoxTerrain))


### PR DESCRIPTION
Permet de corriger le fait que mm3d Malt Ortho plantait si on ne lui indiquait pas d'option envZSup ou envZInf