### PR TITLE
fix: use binary and library install folder as an option

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -142,6 +142,8 @@ option(UPDATE_TRANSLATIONS "Update source translation translations/*.ts files (W
 
 option(WITH_CCACHE  "Use ccache to speed up recompilation" ON)
 
+option(BIN_AUX_FULL_PATH "Binary aux installation path" ${PROJECT_SOURCE_DIR}/binaire-aux/${BIN_AUX_SUBDIR})
+
 # Configure CCache if available
 if(WITH_CCACHE)
 find_program(CCACHE_FOUND ccache)
@@ -177,8 +179,6 @@ endif()
 ######################################
 ## 	Trouver les EXES et Libs	##
 ######################################
-set(BIN_AUX_FULL_PATH ${PROJECT_SOURCE_DIR}/binaire-aux/${BIN_AUX_SUBDIR})
-
 # DEFINITIION : des chemins binaires sous UNIX
 set(UnixBinPath
 		/bin

--- a/CodeExterne/ANN/CMakeLists.txt
+++ b/CodeExterne/ANN/CMakeLists.txt
@@ -1,6 +1,9 @@
 include_directories(${PROJECT_SOURCE_DIR}/CodeExterne/ANN/include)
+if(BUILD_PATH_LIB)
+set(Install_Dir_lib ${BUILD_PATH_LIB})
+else(BUILD_PATH_LIB)
 set(Install_Dir_lib ${PROJECT_SOURCE_DIR}/lib)
-
+endif(BUILD_PATH_LIB)
 set(ANN_SRC_DIR ${PROJECT_SOURCE_DIR}/CodeExterne/ANN/src)
 
 set(ann_source_files ${ANN_SRC_DIR}/ANN.cpp


### PR DESCRIPTION
- [x] ! use binary and library install folder as an option for all subprojects