### PR TITLE
Proposed changes due to newer compilers (e.g. GCC-19)

### DIFF
--- a/CodeExterne/Poisson/include/Ply.h
+++ b/CodeExterne/Poisson/include/Ply.h
@@ -340,7 +340,7 @@ public:
 	PlyOrientedVertex( void ) { ; }
 	PlyOrientedVertex( Point3D< Real > p , Point3D< Real > n ) : point(p) , normal(n) { ; }
   	PlyOrientedVertex operator + ( PlyOrientedVertex p ) const { return PlyOrientedVertex( point+p.point , normal+p.normal ); }
-	PlyOrientedVertex operator - ( PlyOrientedVertex p ) const { return PlyOrientedVertex( point-p.value , normal-p.normal ); }
+	PlyOrientedVertex operator - ( PlyOrientedVertex p ) const { return PlyOrientedVertex( point-p.point , normal-p.normal ); }
 	template< class _Real > PlyOrientedVertex operator * ( _Real s ) const { return PlyOrientedVertex( point*s , normal*s ); }
 	template< class _Real > PlyOrientedVertex operator / ( _Real s ) const { return PlyOrientedVertex( point/s , normal/s ); }
 	PlyOrientedVertex& operator += ( PlyOrientedVertex p ) { point += p.point , normal += p.normal ; return *this; }
@@ -386,7 +386,7 @@ public:
 		}
 
 	  	_PlyColorVertex operator + ( _PlyColorVertex p ) const { return _PlyColorVertex( point+p.point , color+p.color ); }
-		_PlyColorVertex operator - ( _PlyColorVertex p ) const { return _PlyColorVertex( point-p.value , color-p.color ); }
+		_PlyColorVertex operator - ( _PlyColorVertex p ) const { return _PlyColorVertex( point-p.point , color-p.color ); }
 		template< class _Real > _PlyColorVertex operator * ( _Real s ) const { return _PlyColorVertex( point*s , color*s ); }
 		template< class _Real > _PlyColorVertex operator / ( _Real s ) const { return _PlyColorVertex( point/s , color/s ); }
 		_PlyColorVertex& operator += ( _PlyColorVertex p ) { point += p.point , color += p.color ; return *this; }

--- a/CodeExterne/Poisson/include/SparseMatrix.inl
+++ b/CodeExterne/Poisson/include/SparseMatrix.inl
@@ -192,11 +192,11 @@ void SparseMatrix< T >::SetRowSize( int row , int count )
 }
 
 
-template<class T>
-void SparseMatrix<T>::SetZero()
-{
-	Resize(this->m_N, this->m_M);
-}
+// template<class T>
+// void SparseMatrix<T>::SetZero()
+// {
+// 	Resize(this->m_N, this->m_M);
+// }
 
 template<class T>
 SparseMatrix<T> SparseMatrix<T>::operator * (const T& V) const

--- a/include/ext_stl/fixed.h
+++ b/include/ext_stl/fixed.h
@@ -156,8 +156,8 @@ template <const INT b>  class ElPFixed : public ElFixed<b>
 
         void AddScalFixed(const ElPFixed<b> & p2, const INT & aScalFixed)
         {
-             _x+= ((p2.x*this->aSF)<<this->b2);
-             _y+= ((p2.y*this->aSF)<<this->b2);
+             _x+= ((p2.x()*this->aSF())<<this->b2);
+             _y+= ((p2.y()*this->aSF())<<this->b2);
         }
 
 };

--- a/src/TpMMPD/BufferImage_code.h
+++ b/src/TpMMPD/BufferImage_code.h
@@ -393,7 +393,7 @@ BufferImage<T>& BufferImage<T>::operator -= (BufferImage<T> const &img)
     int NC = _size.first;
     int NL = _size.second;
     int NC2,NL2;
-    img.Size(NC2,NL2);
+    img.size(NC2,NL2);
     int nbBands2 = img.numBands();
     T* ptrLine = _data;
     const T* ptrLine2 = img.getPtr();
@@ -434,7 +434,7 @@ BufferImage<T>& BufferImage<T>::operator *= (BufferImage<T> const &img)
     int NC = _size.first;
     int NL = _size.second;
     int NC2,NL2;
-    img.Size(NC2,NL2);
+    img.size(NC2,NL2);
     int nbBands2 = img.numBands();
     T* ptrLine = _data;
     const T* ptrLine2 = img.getPtr();


### PR DESCRIPTION
- Commented out lines 195 to 199 in `CodeExterne/Poisson/include/SparseMatrix.inl` since they generate compiling errors and they are not in used based on https://cgit.freebsd.org/ports/commit/?id=e384c3c58d6e48e729c9b803077702c43cd2ccf8
- Changed `p.value` to `p.point` in lines 343 and 389 of `CodeExterne/Poisson/include/Ply.h` due to typo (https://cgit.freebsd.org/ports/commit/?id=e384c3c58d6e48e729c9b803077702c43cd2ccf8).
- Changed lines 159 and 160 in `include/ext_stl/fixed.h` since they are fucntions based on compiling logs
- Change lines 396 and 437 since there is no function `Size` and I replace it with `size`.